### PR TITLE
Added `foundry` and `semantic-release` release modules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ This is a list of modules that are useful for maintaining or developing modules.
 - https://github.com/zeke/npe
 - https://github.com/zeke/package-json-to-readme
 - https://github.com/zeke/npmwd
+- https://github.com/twolfson/foundry
+- https://github.com/boennemann/semantic-release
 
 ## maintenance bash scripts
 


### PR DESCRIPTION
I was confused by the only release packages from #1 to make it to the README were `bash` based and without tests. I would like to add the 2 well-tested release modules from #1 to the README.

In this PR:
- Added `foundry`, https://github.com/twolfson/foundry
- Added `semantic-release`, https://github.com/boennemann/semantic-release
