### PR TITLE
Add Standard-readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,14 @@ A better `npm publish`. Runs your tests before publishing, bumps version, pushes
 npm i np -g
 ```
 
+### [standard-readme](https://github.com/RichardLitt/standard-readme) by [RichardLitt](https://www.npmjs.com/~richardlitt)
+
+A spec for how a good Readme should be filled out. Includes links to a [Yeoman](http://yeoman.io/) generator for quickly creating structured readmes.
+
+```
+npm i standard-readme -g
+```
+
 ## maintenance bash scripts
 
 ```


### PR DESCRIPTION
This might be a bit premature - right now, it is a specification and a standard-readme yeoman generator. Plans are in the works right now to make a generator that stands alone without needing to install and run yeoman as a dep, as well as a linter using remark. The current spec, however, is still useful as a reference doc at the moment for remembering what sections should be in a good readme.
